### PR TITLE
Removing this to ensure the transition between the login and the dash…

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,25 +1,10 @@
-import { Button, Container, Heading, VStack } from "@chakra-ui/react";
-import { useAuth } from "../contexts/AuthContext";
 import { LoadingScreen } from "@hex-labs/core";
 
-const Dashboard: React.FC = () => {
-  const { loading } = useAuth();
-
-  if (loading) {
-    return <LoadingScreen />;
-  }
-
-  return (
-    <Container mt="8">
-      <VStack spacing="5">
-        <Heading>Register for HackGT 11!</Heading>
-        <a href="https://registration.hexlabs.org">
-          <Button align="center">Go!</Button>
-        </a>
-      </VStack>
-    </Container>
-  );
-};
+/**
+ * The dashboard route is hit briefly during auth handoffs; to avoid flashing
+ * stale marketing content, keep it as a neutral loading screen.
+ */
+const Dashboard: React.FC = () => <LoadingScreen />;
 
 export default Dashboard;
 


### PR DESCRIPTION
I was trying to fix an issue with registration where the dashboard shows "Register for Hack GT 11" I changed that to just a neutral page rather than Register for HackGT11